### PR TITLE
Permanent elements with morphdom

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,14 +2,30 @@
 import "@hotwired/turbo-rails";
 import morphdom from "morphdom";
 
+import { hasAttr } from "./utils";
+
 let prevPath = window.location.pathname;
 
 document.addEventListener("turbo:before-render", (event) => {
   Turbo.navigator.currentVisit.scrolled = prevPath === window.location.pathname;
   prevPath = window.location.pathname;
+
   event.detail.render = async (prevEl, newEl) => {
     await new Promise((resolve) => setTimeout(() => resolve(), 0));
-    morphdom(prevEl, newEl);
+
+    morphdom(prevEl, newEl, {
+      onBeforeElUpdated: (fromEl, toEl) => {
+        return (
+          !fromEl.isEqualNode(toEl) &&
+          !hasAttr(fromEl, "data-morphdom-permanent")
+        );
+      },
+      onElUpdated: (el) => {
+        if (hasAttr(el, "data-morphdom-permanent")) {
+          console.log("it's never gonna happen");
+        }
+      },
+    });
   };
 
   if (document.startViewTransition) {

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -22,7 +22,7 @@ document.addEventListener("turbo:before-render", (event) => {
       },
       onElUpdated: (el) => {
         if (hasAttr(el, "data-morphdom-permanent")) {
-          console.log("it's never gonna happen");
+          console.error("permanent element updated");
         }
       },
     });

--- a/app/javascript/utils.js
+++ b/app/javascript/utils.js
@@ -1,0 +1,2 @@
+export const hasAttr = (el, attr) =>
+    typeof el === "object" && el !== null && "getAttribute" in el && el.hasAttribute(attr);

--- a/app/views/albums/_aside.html.erb
+++ b/app/views/albums/_aside.html.erb
@@ -1,5 +1,5 @@
 <%# locals: (album: nil) -%>
-<%= turbo_frame_tag :aside, class: "aside", target: "_top", data: {"turbo-permanent" => true}, "transition-name" => "aside" do %>
+<%= turbo_frame_tag :aside, class: "aside", target: "_top", data: {"morphdom-permanent" => true}, "transition-name" => "aside" do %>
   <% next unless album %>
   <div transition-id="<%= album.id %>">
     <div class="album-info">

--- a/app/views/shared/_player.html.erb
+++ b/app/views/shared/_player.html.erb
@@ -1,5 +1,5 @@
 <%# locals: (track:, station: nil) -%>
-<div class="player" id="<%= dom_id(station || track, "player_#{track.id}") %>" data-turbo-permanent>
+<div class="player" id="<%= dom_id(station || track, "player_#{track.id}") %>" data-morphdom-permanent>
   <% if track %>
     <div class="player--timeline">
       <div class="player--timeline-progress" style="width:11%;"></div>


### PR DESCRIPTION
Перенести логику перманентных элементов из Turbo в morphdom и сделать так, чтобы элементы остались в DOM-дереве, если нет необходимости их перерисовывать.