### PR TITLE
Sync station pause/resume with subscribers

### DIFF
--- a/app/assets/stylesheets/player.css
+++ b/app/assets/stylesheets/player.css
@@ -16,15 +16,15 @@
   @apply cursor-pointer;
 }
 
-.player-playing .player-btn[data-action="click->player#play"] {
+.player-btn--pause {
   @apply hidden;
 }
 
-.player-btn[data-action="click->player#pause"] {
+.player-playing .player-btn--play {
   @apply hidden;
 }
 
-.player-playing .player-btn[data-action="click->player#pause"] {
+.player-playing .player-btn--pause {
   @apply block;
 }
 

--- a/app/commands/player_command.rb
+++ b/app/commands/player_command.rb
@@ -2,19 +2,54 @@ class PlayerCommand < ApplicationCommand
   prevent_controller_action
 
   def play
-    track_id = element.data.track
-    track = Track.find(track_id)
-
-    if current_user&.live_station&.live?
-      station = current_user.live_station
+    if station
       station.play_now(track)
 
-      Turbo::StreamsChannel.broadcast_update_to station, target: :player, partial: "player/player", locals: {station:, track:}
+      Turbo::StreamsChannel.broadcast_update_to(
+        station, target: :player, partial: "player/player", locals: {station:, track:, is_playing: true}
+      )
 
-      turbo_stream.update("player", partial: "player/player", locals: {station:, track:, live: true})
+      turbo_stream.update("player", partial: "player/player", locals: {station:, track:, live: true, is_playing: true})
       turbo_stream.update(dom_id(station, :queue), partial: "live_stations/queue", locals: {station:})
     else
-      turbo_stream.update("player", partial: "player/player", locals: {track:})
+      turbo_stream.update("player", partial: "player/player", locals: {track:, is_playing: true})
     end
+  end
+
+  def pause
+    toggle_playing(false)
+  end
+
+  def resume
+    toggle_playing(true)
+  end
+
+  private
+
+  def toggle_playing(is_playing)
+    if station
+      Turbo::StreamsChannel.broadcast_invoke_later_to(
+        station,
+        "setAttribute",
+        args: ["data-player-is-playing-value", is_playing.to_s],
+        selector: "[data-controller='player']"
+      )
+    end
+    turbo_stream.invoke(
+      "setAttribute",
+      args: ["data-player-is-playing-value", is_playing.to_s],
+      selector: "[data-controller='player']"
+    )
+  end
+
+  def track
+    @track ||= begin
+      track_id = element.data.track
+      Track.find(track_id)
+    end
+  end
+
+  def station
+    @station ||= current_user&.live_station&.live? ? current_user.live_station : nil
   end
 end

--- a/app/javascript/controllers/player_controller.js
+++ b/app/javascript/controllers/player_controller.js
@@ -14,13 +14,12 @@ function secondsToDuration(num) {
 export default class extends Controller {
   static targets = ["progress", "time"];
   static outlets = ["track"];
-  static values = { duration: Number, track: String, nextTrackUrl: String };
+  static values = { duration: Number, track: String, nextTrackUrl: String, isPlaying: Boolean };
   static classes = ["playing"];
 
   initialize() {
     this.handleTimeUpdate = this.handleTimeUpdate.bind(this);
     this.handleEnded = this.handleEnded.bind(this);
-    this.playing = false;
   }
 
   trackValueChanged() {
@@ -36,6 +35,14 @@ export default class extends Controller {
     }
   }
 
+  isPlayingValueChanged() {
+    if (this.isPlayingValue) {
+      this.play();
+    } else {
+      this.pause();
+    }
+  }
+
   trackOutletConnected(outlet, el) {
     outlet.togglePlayingIfMatch(this.trackValue);
   }
@@ -46,7 +53,7 @@ export default class extends Controller {
       this.setupAudioListeners();
     }
 
-    if (this.playing) {
+    if (this.isPlayingValue) {
       this.play();
     }
   }
@@ -60,13 +67,11 @@ export default class extends Controller {
   play() {
     this.element.classList.add(this.playingClass);
     this.audio.play();
-    this.playing = true;
   }
 
   pause() {
     this.element.classList.remove(this.playingClass);
     this.audio.pause();
-    this.playing = false;
   }
 
   seek(e) {

--- a/app/views/player/_player.html.erb
+++ b/app/views/player/_player.html.erb
@@ -1,8 +1,9 @@
-<%# locals: (track:, station: nil, live: false) -%>
+<%# locals: (track:, station: nil, live: false, is_playing: false) -%>
 <div class="player"
   data-controller="player"
   data-player-duration-value="<%= track&.duration %>"
   data-player-track-value="<%= track&.id %>"
+  data-player-is-playing-value="<%= is_playing %>"
   data-player-playing-class="player-playing"
   data-player-next-track-url-value="<%= live ? play_next_live_station_path : (!station && play_next_track_path(track))%>"
   data-player-track-outlet=".track"
@@ -12,14 +13,14 @@
       <div class="player--timeline-progress" style="width:0%;" data-player-target="progress"></div>
     </div>
   <% end %>
-  <% unless station %>
+  <% if live || !station %>
   <div class="player--controls">
-    <span class="player-btn" data-action="click->player#play">
+    <%= button_to "#", method: :post, form: {class: "player-btn player-btn--play", data: {"turbo-command" => "PlayerCommand#resume"}} do %>
       <%= render "icons/play" %>
-    </span>
-    <span class="player-btn" data-action="click->player#pause">
+    <% end %>
+    <%= button_to "#", method: :post, form: {class: "player-btn player-btn--pause", data: {"turbo-command" => "PlayerCommand#pause"}} do %>
       <%= render "icons/pause" %>
-    </span>
+    <% end %>
   </div>
   <% end %>
   <div class="player--track">


### PR DESCRIPTION
Добавить возможность автору трансляции ставить проигрывание трека на паузу (и обратно) и синхронизировать эти действия со слушателями.

![3z5SDDqOsZ](https://github.com/foxy-eyed/workshop_hotwire/assets/19491749/1cb8cd4b-1df8-4f61-b85d-d3e87a03b4c7)
